### PR TITLE
[GH-1] added section for other listings of tech conferences

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,17 @@
 # Open-source-Conferences
+
 Links to various open-source conferences related to computer science.
+
+### Specific Events
 
 **Open Source India**: https://www.opensourceindia.in/
 
 **PyCon India 2018**: https://in.pycon.org/2018/
+
+### Conference lists
+
+*check for regular monthly updates*
+
+**TechMeme conference list**: https://github.com/johncoleman83/Open-source-Conferences.git
+
+**OpenSource.com**: https://opensource.com/resources/conferences-and-events-monthly


### PR DESCRIPTION
Per issue #1 I added a section for other open source conference lists.  TechMeme does not only list open source conferences, but it does have a lot of conferences listed such as NGINX conf and it is International and updated regularly.